### PR TITLE
Updated for Jetbrains 2022.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@ pluginName_=casbin-idea-plugin
 pluginGroup=io.github.will7200.plugins.casbin
 pluginVersion=0.1.10
 pluginSinceBuild=201.6668
-pluginUntilBuild=222.*
+pluginUntilBuild=223.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions=2020.1.4, 2020.2.3, 2020.3.2, 2021.1, 2021.2, 2021.3, 2022.1, 2022.2
+pluginVerifierIdeVersions=2020.1.4, 2020.2.3, 2020.3.2, 2021.1, 2021.2, 2021.3, 2022.1, 2022.2, 2022.3
 platformType=IIC
 platformVersion=2020.3
 platformDownloadSources=true


### PR DESCRIPTION
I wanted to use the plugin and JB wouldn't install so I figured I would review your previous changes and it appeared only to require version updates in the gradle.properties